### PR TITLE
Fix missing pymupdf dependency in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 openai>=1.40.0
-pypdf>=4.2.0
+pymupdf>=1.24.0
 python-dotenv>=1.0.1
 tqdm>=4.66.4
 together>=1.2.0
+matplotlib>=3.7.0


### PR DESCRIPTION
- Added pymupdf>=1.24.0 (required by mupdf_trainer_v2.py line 20)
- Replaced unused pypdf with pymupdf
- Added matplotlib>=3.7.0 (imported at line 18)

This fixes the ModuleNotFoundError that occurs when running mupdf_trainer_v2.py after a fresh install from requirements.txt.

Resolves: Missing critical dependency issue